### PR TITLE
Scaffold generator should respect attribute:richer_text

### DIFF
--- a/lib/generators/richer_text/install/install_generator.rb
+++ b/lib/generators/richer_text/install/install_generator.rb
@@ -14,6 +14,11 @@ module RicherText
           "app/views/richer_text/contents/_content.html.erb",
           "app/views/richer_text/contents/_content.html.erb"
         )
+
+        copy_file(
+          "lib/templates/active_record/model/model.rb.tt",
+          "lib/templates/active_record/model/model.rb.tt"
+        )
       end
 
       def install_javascript_dependencies

--- a/lib/richer_text.rb
+++ b/lib/richer_text.rb
@@ -1,6 +1,7 @@
 require "active_support"
 require "active_support/rails"
 
+require "richer_text/generated_attributes"
 require "richer_text/version"
 require "richer_text/engine"
 

--- a/lib/richer_text/generated_attributes.rb
+++ b/lib/richer_text/generated_attributes.rb
@@ -1,0 +1,75 @@
+# /lib/rails_ext/generated_attribute.rb
+
+# Here, we patch the GeneratedAttribute class to add `richer_text` as a field type, which behaves much the same as the `rich_text` type.
+# We will patch the Model generator as well to tweak the ActiveRecord model generated when this type is used
+require 'rails/generators/generated_attribute'
+
+module Rails
+  module Generators
+    class GeneratedAttribute
+      DEFAULT_TYPES = %w(
+        attachment
+        attachments
+        belongs_to
+        boolean
+        date
+        datetime
+        decimal
+        digest
+        float
+        integer
+        references
+        rich_text
+        string
+        text
+        time
+        timestamp
+        token
+        richer_text
+      )
+
+      def field_type
+        @field_type ||= case type
+                        when :integer                  then :number_field
+                        when :float, :decimal          then :text_field
+                        when :time                     then :time_field
+                        when :datetime, :timestamp     then :datetime_field
+                        when :date                     then :date_field
+                        when :text                     then :text_area
+                        when :rich_text                then :rich_text_area
+                        when :boolean                  then :check_box
+                        when :attachment, :attachments then :file_field
+                        when :richer_text              then :richer_text_area
+                        else
+                          :text_field
+        end
+      end
+
+      def default
+        @default ||= case type
+                     when :integer                     then 1
+                     when :float                       then 1.5
+                     when :decimal                     then "9.99"
+                     when :datetime, :timestamp, :time then Time.now.to_fs(:db)
+                     when :date                        then Date.today.to_fs(:db)
+                     when :string                      then name == "type" ? "" : "MyString"
+                     when :text                        then "MyText"
+                     when :boolean                     then false
+                     when :references, :belongs_to,
+                          :attachment, :attachments,
+                          :rich_text, :richer_text     then nil
+                     else
+                       ""
+        end
+      end
+
+      def virtual?
+        richer_text? || rich_text? || attachment? || attachments?
+      end
+
+      def richer_text?
+        type == :richer_text
+      end
+    end
+  end
+end

--- a/lib/templates/active_record/model/model.rb.tt
+++ b/lib/templates/active_record/model/model.rb.tt
@@ -1,0 +1,25 @@
+<% module_namespacing do -%>
+class <%= class_name %> < <%= parent_class_name.classify %>
+<% attributes.select(&:reference?).each do |attribute| -%>
+  belongs_to :<%= attribute.name %><%= ", polymorphic: true" if attribute.polymorphic? %>
+<% end -%>
+<% attributes.select(&:rich_text?).each do |attribute| -%>
+  has_rich_text :<%= attribute.name %>
+<% end -%>
+<% attributes.select(&:richer_text?).each do |attribute| -%>
+  has_richer_text :<%= attribute.name %>
+<% end -%>
+<% attributes.select(&:attachment?).each do |attribute| -%>
+  has_one_attached :<%= attribute.name %>
+<% end -%>
+<% attributes.select(&:attachments?).each do |attribute| -%>
+  has_many_attached :<%= attribute.name %>
+<% end -%>
+<% attributes.select(&:token?).each do |attribute| -%>
+  has_secure_token<% if attribute.name != "token" %> :<%= attribute.name %><% end %>
+<% end -%>
+<% if attributes.any?(&:password_digest?) -%>
+  has_secure_password
+<% end -%>
+end
+<% end -%>


### PR DESCRIPTION
Currently its a little rough patching the GeneratedAttribute class and then copying over a model generator to lib/templates/active_record/model/model.rb.tt file to the application to generate correctly.

That's not idea as the developer may forget about this file and Rails upgrades may break this file.