### PR TITLE
Adds JSON storage ability

### DIFF
--- a/app/assets/stylesheets/richer_text/richer-text.css
+++ b/app/assets/stylesheets/richer_text/richer-text.css
@@ -34,3 +34,9 @@
 .richer-text img {
   width: 100%;
 }
+
+.richer-text blockquote {
+  border-left: 2px solid #ced4da;
+  margin: 0;
+  padding: 0 0 0 10px;
+}

--- a/app/assets/stylesheets/richer_text/richer-text.css
+++ b/app/assets/stylesheets/richer_text/richer-text.css
@@ -18,6 +18,7 @@
 
 .richer-text table td>*,
 .richer-text table th>* {
+  margin-top: 0;
   margin-bottom: 0;
 }
 
@@ -32,11 +33,11 @@
 }
 
 .richer-text img {
-  width: 100%;
+  width: auto;
 }
 
 .richer-text blockquote {
   border-left: 2px solid #ced4da;
-  margin: 0;
+  margin: 1rem 0.5rem;
   padding: 0 0 0 10px;
 }

--- a/app/helpers/richer_text/tag_helper.rb
+++ b/app/helpers/richer_text/tag_helper.rb
@@ -11,6 +11,7 @@ module ActionView::Helpers
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :richer_text_input].compact.join("_")) if object
       options["value"] = options.fetch("value") { value&.to_editor_format }
+      options["serializer"] = options.fetch("serializer") { object.class.send(:"richer_text_#{@method_name}_json") ? "json" : "html" }
 
       @template_object.richer_text_area_tag(options.delete("name"), options["value"], options.except("value"))
     end
@@ -39,6 +40,9 @@ module RicherText
 
       # So that we can access the content in the tiptap editor
       options[:content] ||= value
+
+      # So we can choose the serializer to use, e.g. "html" or "json"
+      options[:serializer] ||= "html"
 
       input_tag = hidden_field_tag(name, value, id: options[:input])
       editor_tag = tag("richer-text-editor", options)

--- a/app/helpers/richer_text/tag_helper.rb
+++ b/app/helpers/richer_text/tag_helper.rb
@@ -10,7 +10,7 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :richer_text_input].compact.join("_")) if object
-      options["value"] = options.fetch("value") { value&.to_html }
+      options["value"] = options.fetch("value") { value&.to_editor_format }
 
       @template_object.richer_text_area_tag(options.delete("name"), options["value"], options.except("value"))
     end

--- a/app/models/richer_text/json_text.rb
+++ b/app/models/richer_text/json_text.rb
@@ -1,0 +1,43 @@
+module RicherText
+  class JsonText < ApplicationRecord
+    DEFAULT_BODY = {"type" => "doc", "content" => [{"type" => "paragraph", "attrs" => {"textAlign" => "left"}}]}
+
+    belongs_to :record, polymorphic: true, touch: true
+
+    serialize :body, JSON, default: DEFAULT_BODY.to_json
+
+    has_many_attached :images
+
+    before_save :update_images
+
+    def to_editor_format
+      body
+    end
+
+    def to_s
+      RicherText.default_renderer.visit(document)
+    end
+
+    private
+
+    def update_images
+      self.images = image_nodes.map(&:signed_id)
+    end
+
+    def image_nodes
+      find_nodes_of_type(RicherText::Nodes::Image).flatten.compact_blank
+    end
+
+    def find_nodes_of_type(type, node = document)
+      if node.children.any?
+        node.children.map { |child| find_nodes_of_type(type, child) }
+      else
+        node.is_a?(type) ? node : nil
+      end
+    end
+
+    def document
+      @document ||= RicherText::Node.build(body)
+    end
+  end
+end

--- a/app/models/richer_text/rich_text.rb
+++ b/app/models/richer_text/rich_text.rb
@@ -15,6 +15,10 @@ module RicherText
       body&.to_html&.to_s
     end
 
+    def to_editor_format
+      body&.to_html&.to_s
+    end
+
     private
 
     def update_images

--- a/db/migrate/20230916224959_create_richer_text_json_texts.rb
+++ b/db/migrate/20230916224959_create_richer_text_json_texts.rb
@@ -1,7 +1,7 @@
 class CreateRicherTextJsonTexts < ActiveRecord::Migration[7.0]
   def change
     create_table :richer_text_json_texts do |t|
-      t.string :name
+      t.string :name, null: false
       t.text :body, size: :long
       t.references :record, null: false, polymorphic: true
 

--- a/db/migrate/20230916224959_create_richer_text_json_texts.rb
+++ b/db/migrate/20230916224959_create_richer_text_json_texts.rb
@@ -1,0 +1,13 @@
+class CreateRicherTextJsonTexts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :richer_text_json_texts do |t|
+      t.string :name
+      t.text :body, size: :long
+      t.references :record, null: false, polymorphic: true
+
+      t.timestamps
+
+      t.index [:record_type, :record_id, :name], name: "index_richer_texts_rich_json_uniqueness", unique: true
+    end
+  end
+end

--- a/lib/richer_text.rb
+++ b/lib/richer_text.rb
@@ -13,4 +13,38 @@ module RicherText
   autoload :Fragment
   autoload :Serialization
   autoload :TagHelper
+
+  autoload :Node
+  autoload :Mark
+  autoload :HTMLVisitor
+
+  module Nodes
+    extend ActiveSupport::Autoload
+
+    autoload :Blockquote
+    autoload :BulletList
+    autoload :Callout
+    autoload :CodeBlock
+    autoload :Doc
+    autoload :HardBreak
+    autoload :Heading
+    autoload :HorizontalRule
+    autoload :Image
+    autoload :ListItem
+    autoload :Paragraph
+    autoload :OrderedList
+    autoload :Text
+    autoload :Table
+    autoload :TableCell
+    autoload :TableRow
+    autoload :TableHeader
+  end
+
+  class << self
+    def default_renderer
+      @default_renderer ||= RicherText::HTMLVisitor.new
+    end
+
+    attr_writer :default_renderer
+  end
 end

--- a/lib/richer_text/attribute.rb
+++ b/lib/richer_text/attribute.rb
@@ -3,7 +3,7 @@ module RicherText
     extend ActiveSupport::Concern
 
     class_methods do
-      def has_richer_text(name)
+      def has_richer_text(name, json: false)
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}
             richer_text_#{name} || build_richer_text_#{name}
@@ -19,7 +19,7 @@ module RicherText
         CODE
 
         has_one :"richer_text_#{name}", -> { where(name: name) },
-          class_name: "RicherText::RichText", as: :record, inverse_of: :record, autosave: true, dependent: :destroy
+          class_name: json ? "RicherText::JsonText" : "RicherText::RichText", as: :record, inverse_of: :record, autosave: true, dependent: :destroy
 
         scope :"with_richer_text_#{name}", -> { includes("richer_text_#{name}") }
       end

--- a/lib/richer_text/attribute.rb
+++ b/lib/richer_text/attribute.rb
@@ -4,6 +4,10 @@ module RicherText
 
     class_methods do
       def has_richer_text(name, json: false)
+        # Store if the attribute is using JSON or not.
+        class_attribute :"richer_text_#{name}_json", instance_writer: false
+        self.send(:"richer_text_#{name}_json=", json)
+
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}
             richer_text_#{name} || build_richer_text_#{name}

--- a/lib/richer_text/html_visitor.rb
+++ b/lib/richer_text/html_visitor.rb
@@ -1,0 +1,85 @@
+module RicherText
+  class HTMLVisitor
+    include ActionView::Helpers::TagHelper
+
+    def visit(node)
+      node.accept(self)
+    end
+
+    def visit_blockquote(node)
+      "<blockquote>#{visit_children(node).join}</blockquote>"
+    end
+
+    def visit_bullet_list(node)
+      "<ul>#{visit_children(node).join}</ul>"
+    end
+
+    def visit_callout(node)
+      "<div class='callout' data-color='#{node.color}'>#{visit_children(node).join}</div>"
+    end
+
+    def visit_children(node)
+      node.children.map { |child| visit(child) }
+    end
+
+    def visit_code_block(node)
+      "<pre><code>#{visit_children(node).join("\n")}</code></pre>"
+    end
+
+    def visit_doc(node)
+      "<div class='richer-text'>#{visit_children(node).join("\n")}</div>".html_safe
+    end
+
+    def visit_paragraph(node)
+      "<p style='#{node.style}'>#{visit_children(node).join}</p>"
+    end
+
+    def visit_list_item(node)
+      "<li>#{visit_children(node).join}</li>"
+    end
+
+    def visit_ordered_list(node)
+      "<ol>#{visit_children(node).join}</ol>"
+    end
+
+    def visit_heading(node)
+      "<h#{node.level}>#{visit_children(node).join}</h#{node.level}>"
+    end
+
+    def visit_hard_break(_node)
+      "<br>"
+    end
+
+    def visit_horizontal_rule(_node)
+      "<div><hr></div>"
+    end
+
+    def visit_image(node)
+      "<img src='#{node.src}' />"
+    end
+
+    def visit_text(node, marks)
+      if marks.empty?
+        node.text
+      else
+        content_tag(marks[0].tag, visit_text(node, marks[1..]), marks[0].attrs)
+      end
+    end
+
+    def visit_table(node)
+      "<table>#{visit_children(node).join}</table>"
+    end
+
+    def visit_table_row(node)
+      "<tr>#{visit_children(node).join}</tr>"
+    end
+
+    def visit_table_cell(node)
+      "<td>#{visit_children(node).join}</td>"
+    end
+
+    def visit_table_header(node)
+      "<th>#{visit_children(node).join}</th>"
+    end
+  end
+end

--- a/lib/richer_text/mark.rb
+++ b/lib/richer_text/mark.rb
@@ -1,0 +1,23 @@
+module RicherText
+  class Mark
+    attr_reader :attrs, :type
+
+    TAGS = {
+      "bold" => "strong",
+      "italic" => "em",
+      "strike" => "del",
+      "code" => "code",
+      "highlight" => "mark",
+      "link" => "a"
+    }
+
+    def initialize(json)
+      @attrs = json.fetch("attrs", {})
+      @type = json.fetch("type", nil)
+    end
+
+    def tag
+      TAGS[type] || "span"
+    end
+  end
+end

--- a/lib/richer_text/node.rb
+++ b/lib/richer_text/node.rb
@@ -1,0 +1,30 @@
+module RicherText
+  class Node
+    attr_reader :json, :attrs, :children, :type
+
+    STYLES = {
+      "textAlign" => "text-align",
+    }
+
+    def self.build(json)
+      node = json.is_a?(String) ? JSON.parse(json) : json
+      klass = "RicherText::Nodes::#{node["type"].underscore.classify}".safe_constantize
+      klass.new(node)
+    end
+
+    def initialize(json)
+      @json = json
+      @attrs = json.fetch("attrs", {})
+      @type = json.fetch("type", "text")
+      @children = json.fetch("content", []).map { |child| self.class.build(child) }
+    end
+
+    def style
+      @attrs.select { |k, v| STYLES.key?(k) }.map { |k, v| "#{STYLES[k]}: #{v};" }.join
+    end
+
+    def accept(visitor)
+      visitor.send("visit_#{type.underscore}", self)
+    end
+  end
+end

--- a/lib/richer_text/nodes/blockquote.rb
+++ b/lib/richer_text/nodes/blockquote.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class Blockquote < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/bullet_list.rb
+++ b/lib/richer_text/nodes/bullet_list.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class BulletList < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/callout.rb
+++ b/lib/richer_text/nodes/callout.rb
@@ -1,0 +1,9 @@
+module RicherText
+  module Nodes
+    class Callout < ::RicherText::Node
+      def color
+        attrs["data-color"]
+      end
+    end
+  end
+end

--- a/lib/richer_text/nodes/code_block.rb
+++ b/lib/richer_text/nodes/code_block.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class CodeBlock < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/doc.rb
+++ b/lib/richer_text/nodes/doc.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class Doc < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/hard_break.rb
+++ b/lib/richer_text/nodes/hard_break.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class HardBreak < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/heading.rb
+++ b/lib/richer_text/nodes/heading.rb
@@ -1,0 +1,9 @@
+module RicherText
+  module Nodes
+    class Heading < ::RicherText::Node
+      def level
+        attrs["level"]
+      end
+    end
+  end
+end

--- a/lib/richer_text/nodes/horizontal_rule.rb
+++ b/lib/richer_text/nodes/horizontal_rule.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class HorizontalRule < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/image.rb
+++ b/lib/richer_text/nodes/image.rb
@@ -1,0 +1,13 @@
+module RicherText
+  module Nodes
+    class Image < ::RicherText::Node
+      def src
+        @src ||= attrs['src']
+      end
+
+      def signed_id
+        @signed_id = attrs['signedId']
+      end
+    end
+  end
+end

--- a/lib/richer_text/nodes/list_item.rb
+++ b/lib/richer_text/nodes/list_item.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class ListItem < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/ordered_list.rb
+++ b/lib/richer_text/nodes/ordered_list.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class OrderedList < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/paragraph.rb
+++ b/lib/richer_text/nodes/paragraph.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class Paragraph < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/table.rb
+++ b/lib/richer_text/nodes/table.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class Table < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/table_cell.rb
+++ b/lib/richer_text/nodes/table_cell.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class TableCell < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/table_header.rb
+++ b/lib/richer_text/nodes/table_header.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class TableHeader < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/table_row.rb
+++ b/lib/richer_text/nodes/table_row.rb
@@ -1,0 +1,6 @@
+module RicherText
+  module Nodes
+    class TableRow < ::RicherText::Node
+    end
+  end
+end

--- a/lib/richer_text/nodes/text.rb
+++ b/lib/richer_text/nodes/text.rb
@@ -1,0 +1,18 @@
+module RicherText
+  module Nodes
+    class Text < ::RicherText::Node
+      def initialize(json)
+        @marks = json.fetch("marks", []).map { |mark| RicherText::Mark.new(mark) }
+        super(json)
+      end
+
+      def text
+        json["text"]
+      end
+
+      def accept(visitor)
+        visitor.visit_text(self, @marks)
+      end
+    end
+  end
+end

--- a/test/fixtures/richer_text/json_texts.yml
+++ b/test/fixtures/richer_text/json_texts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  body: MyText
+  record: one
+
+two:
+  name: MyString
+  body: MyText
+  record: two

--- a/test/models/richer_text/json_text_test.rb
+++ b/test/models/richer_text/json_text_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module RicherText
+  class JsonTextTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
## Adds JSON storage, rendering ability

This introduces a fully supported JSON storage / renderer to Richer Text. 

To use:

```ruby
has_richer_text :body, json: true
```

Then call the `richer_text_area` form helper like usual and things will automatically be serialized to/from JSON

```erb
<%= form.richer_text_area :body, callouts: true, tables: true %>
```

You'll see a RicherText::JsonText record is created on the backend for `post.body`. Calling `to_s` on body will return the fully rendered HTML from the JSON that's stored.

## Overriding the default visitor

RicherText supports overriding the default visitor like so

in config/initializers create a file.

```rb
Rails.configuration.to_prepare do
  RicherText.default_renderer = HtmlVisitor.new
end
```

Then create your own HtmlVisitor in your app

```rb
class HtmlVisitor < RicherText::HTMLVisitor
  def visit_callout(node)
    "<div class='callout' data-color='#{node.color}'>#{visit_children(node).join}</div>"
  end
end
```

and you can proceed to override default methods to customize the rendering completely.