### PR TITLE
Introduce oembed support

### DIFF
--- a/app/models/richer_text/o_embed.rb
+++ b/app/models/richer_text/o_embed.rb
@@ -1,0 +1,81 @@
+require "oembed"
+
+module RicherText
+  class OEmbed < ApplicationRecord
+    include RicherText::Embeddable
+
+    PATTERNS = [
+      {source: "^http:\\/\\/([^\\.]+\\.)?flickr\\.com\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?flickr\\.com\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/flic\\.kr\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/flic\\.kr\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?imgur\\.com\\/gallery\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/([^\\.]+\\.)?imgur\\.com\\/gallery\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/instagr\\.am\\/p\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/instagram\\.com\\/p\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/www\\.instagram\\.com\\/p\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/instagr\\.am\\/p\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/instagram\\.com\\/p\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/www\\.instagram\\.com\\/p\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/([^\\.]+\\.)?soundcloud\\.com\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?soundcloud\\.com\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/open\\.spotify\\.com\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/open\\.spotify\\.com\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/play\\.spotify\\.com\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/play\\.spotify\\.com\\/(.*?)", options: ""},
+      {source: "^spotify\\:(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?twitter\\.com\\/(.*?)\\/status\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/([^\\.]+\\.)?vimeo\\.com\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?vimeo\\.com\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/([^\\.]+\\.)?youtube\\.com\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?youtube\\.com\\/(.*?)", options: ""},
+      {source: "^http:\\/\\/([^\\.]+\\.)?youtu\\.be\\/(.*?)", options: ""},
+      {source: "^https:\\/\\/([^\\.]+\\.)?youtu\\.be\\/(.*?)", options: ""}
+    ]
+
+    def self.from_url(url)
+      find_by!(url: url)
+    rescue ActiveRecord::RecordNotFound
+      resource = ::OEmbed::Providers.get(url)
+      create!(url: url, fields: resource.fields)
+    end
+
+    def self.delegate_fields(*keys)
+      keys.each do |key|
+        define_method(key) do
+          fields[key.to_s]
+        end
+      end
+    end
+
+    delegate_fields(
+      :type,
+      :version,
+      :title,
+      :author_name,
+      :author_url,
+      :provider_name,
+      :provider_url,
+      :thumbnail_url,
+      :thumbnail_width,
+      :thumbnail_height,
+      :height,
+      :width,
+      :html
+    )
+
+    %w[link photo rich video].each do |embed_type|
+      define_method "#{embed_type}?" do
+        type == embed_type
+      end
+    end
+
+    def to_embeddable_partial_path
+      "richer_text/o_embeds/embed"
+    end
+
+    def to_richer_text_editor_partial_path
+      "richer_text/o_embeds/richer_text_editor_embed"
+    end
+  end
+end

--- a/app/views/richer_text/o_embeds/_embed.html.erb
+++ b/app/views/richer_text/o_embeds/_embed.html.erb
@@ -1,0 +1,11 @@
+<% if o_embed.thumbnail_url && !o_embed.html %>
+  <div class="embed">
+    <%= image_tag o_embed.thumbnail_url %>
+  </div>
+<% elsif o_embed.html %>
+  <div class="embed">
+    <%= o_embed.html.html_safe %>
+  </div>
+<% elsif o_embed.provider_name %>
+  <%= link_to o_embed.provider_name, o_embed.url %>
+<% end %>

--- a/app/views/richer_text/o_embeds/_richer_text_editor_embed.html.erb
+++ b/app/views/richer_text/o_embeds/_richer_text_editor_embed.html.erb
@@ -1,0 +1,11 @@
+<% if o_embed.thumbnail_url %>
+  <div class="embed">
+    <%= image_tag o_embed.thumbnail_url %>
+  </div>
+<% elsif o_embed.html %>
+  <div class="embed">
+    <%= o_embed.html.html_safe %>
+  </div>
+<% elsif o_embed.provider_name %>
+  <%= link_to o_embed.provider_name, o_embed.url %>
+<% end %>

--- a/db/migrate/20230926034114_create_richer_text_o_embeds.rb
+++ b/db/migrate/20230926034114_create_richer_text_o_embeds.rb
@@ -1,0 +1,10 @@
+class CreateRicherTextOEmbeds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :richer_text_o_embeds do |t|
+      t.jsonb :fields
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/richer_text/embed.rb
+++ b/lib/richer_text/embed.rb
@@ -17,11 +17,11 @@ module RicherText
       @embed
     end
 
-    delegate :to_embeddable_partial_path, to: :@embed
+    delegate :to_richer_text_editor_partial_path, to: :@embed
     delegate :model_name, to: :@embed
 
     def html
-      render partial: to_embeddable_partial_path, object: object, as: model_name.element
+      render partial: to_richer_text_editor_partial_path, object: object, as: model_name.element
     end
   end
 end

--- a/lib/richer_text/embeddable.rb
+++ b/lib/richer_text/embeddable.rb
@@ -10,6 +10,10 @@ module RicherText
       def to_embeddable_partial_path
         to_partial_path
       end
+
+      def to_richer_text_editor_partial_path
+        to_partial_path
+      end
     end
   end
 end

--- a/lib/richer_text/engine.rb
+++ b/lib/richer_text/engine.rb
@@ -1,4 +1,5 @@
 require "rails"
+require "oembed"
 
 module RicherText
   class Engine < ::Rails::Engine
@@ -14,6 +15,14 @@ module RicherText
       ActiveSupport.on_load(:action_controller) do
         helper RicherText::TagHelper
       end
+    end
+
+    config.after_initialize do
+      ::OEmbed::Providers.register_all
+      ::OEmbed::Providers.register_fallback(
+        ::OEmbed::ProviderDiscovery,
+        ::OEmbed::Providers::Noembed
+      )
     end
   end
 end

--- a/lib/richer_text/html_visitor.rb
+++ b/lib/richer_text/html_visitor.rb
@@ -82,7 +82,7 @@ module RicherText
     end
 
     def visit_image(node)
-      "<img src='#{node.src}' />"
+      "<img src='#{node.src}' width='#{node.width}' />"
     end
 
     def visit_text(node, marks)

--- a/lib/richer_text/nodes/image.rb
+++ b/lib/richer_text/nodes/image.rb
@@ -8,6 +8,10 @@ module RicherText
       def signed_id
         @signed_id = attrs['signedId']
       end
+
+      def width
+        attrs['width']
+      end
     end
   end
 end

--- a/lib/richer_text/nodes/richer_text_embed.rb
+++ b/lib/richer_text/nodes/richer_text_embed.rb
@@ -7,7 +7,7 @@ module RicherText
 
       def html
         render partial: embeddable.to_embeddable_partial_path, object: embeddable, as: embeddable.model_name.element
-      rescue ActiveRecord::RecordNotFound
+      rescue ActiveRecord::RecordNotFound, NoMethodError
         "" # TODO: handle this better
       end
 

--- a/richer_text.gemspec
+++ b/richer_text.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", "> 7.0.0"
+  spec.add_dependency "ruby-oembed"
 end

--- a/test/fixtures/richer_text/o_embeds.yml
+++ b/test/fixtures/richer_text/o_embeds.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  fields: 
+  url: MyString
+
+two:
+  fields: 
+  url: MyString

--- a/test/models/richer_text/o_embed_test.rb
+++ b/test/models/richer_text/o_embed_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module RicherText
+  class OEmbedTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
- Introduces oEmbed support built into the gem. 
- Uses ruby-oembed as a provider for Oembed lookups.
- Adds `to_richer_text_editor_partial_path` for rendering partials inside of the iframe of the Richer Text Editor.