### PR TITLE
Add placeholder `richer_text/tag_helper` to appease Zeitwerk autoloader

### DIFF
--- a/lib/richer_text/tag_helper.rb
+++ b/lib/richer_text/tag_helper.rb
@@ -1,0 +1,4 @@
+module RicherText
+  module TagHelper
+  end
+end


### PR DESCRIPTION
* The `RicherText::Engine` was failing to load because it was looking for `richer_text/tag_helper`
	* While the actual helper is defined in `app/helpers/richer_text/tag_helper.rb`, this placeholder module definition gives Zeitwerk the loading path it expects