### PR TITLE
Add text visitor and to_plain_text method on JsonText model

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ document.addEventListener("turbo:load", (event) => {
 
 ## Usage
 
-> [!WARNING]  
-> You probably shouldn't use this gem / npm package (yet!) for anything serious. It's still undergoing development. But please do try it on a non-production app!
-
 To use RicherText, once you've completed the installation process is a matter of doing the following:
 
 **Add has_richer_text to a model**

--- a/app/models/richer_text/json_text.rb
+++ b/app/models/richer_text/json_text.rb
@@ -19,6 +19,10 @@ module RicherText
       RicherText.default_renderer.visit(document)
     end
 
+    def to_plain_text
+      RicherText.default_text_renderer.visit(document)
+    end
+
     def mentionees
       gids = mention_nodes.map(&:id).compact_blank
 

--- a/lib/richer_text.rb
+++ b/lib/richer_text.rb
@@ -20,6 +20,7 @@ module RicherText
   autoload :Node
   autoload :Mark
   autoload :HTMLVisitor
+  autoload :TextVisitor
 
   module Nodes
     extend ActiveSupport::Autoload
@@ -53,10 +54,14 @@ module RicherText
       @default_renderer ||= RicherText::HTMLVisitor.new
     end
 
+    def default_text_renderer
+      @default_text_renderer ||= RicherText::TextVisitor.new
+    end
+
     def default_form_options
       @default_form_options ||= {}
     end
 
-    attr_writer :default_renderer, :default_form_options
+    attr_writer :default_renderer, :default_text_renderer, :default_form_options
   end
 end

--- a/lib/richer_text/text_visitor.rb
+++ b/lib/richer_text/text_visitor.rb
@@ -1,0 +1,93 @@
+module RicherText
+  class TextVisitor
+    def visit(node)
+      node.accept(self)
+    end
+
+    def visit_attachment_figure(node)
+      visit_children(node)
+    end
+
+    def visit_attachment_gallery(node)
+      visit_children(node)
+    end
+
+    def visit_blockquote(node)
+      visit_children(node)
+    end
+
+    def visit_bullet_list(node)
+      visit_children(node)
+    end
+
+    def visit_callout(node)
+      visit_children(node)
+    end
+
+    def visit_children(node)
+      node.children.map { |child| visit(child) }.join(" ")
+    end
+
+    def visit_code_block(node)
+    end
+
+    def visit_doc(node)
+      visit_children(node)
+    end
+
+    def visit_iframely_embed(node)
+    end
+
+    def visit_mention(node, _marks)
+      node.name
+    end
+
+    def visit_paragraph(node)
+      visit_children(node)
+    end
+
+    def visit_richer_text_embed(node)
+    end
+
+    def visit_list_item(node)
+      visit_children(node)
+    end
+
+    def visit_ordered_list(node)
+      visit_children(node)
+    end
+
+    def visit_heading(node)
+      visit_children(node)
+    end
+
+    def visit_hard_break(_node)
+    end
+
+    def visit_horizontal_rule(_node)
+    end
+
+    def visit_image(_node)
+    end
+
+    def visit_text(node, _marks)
+      node.text
+    end
+
+    def visit_table(node)
+      visit_children(node)
+    end
+
+    def visit_table_row(node)
+      visit_children(node)
+    end
+
+    def visit_table_cell(node)
+      visit_children(node)
+    end
+
+    def visit_table_header(node)
+      visit_children(node)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for `to_plain_text` as a method on the JsonText record, for cases when you need plain text.

It allows overriding the default_text_renderer with your own TextVisitor in your applications, much like replacing the default_renderer (HTML Visitor) works.


```
class TextVisitor < RicherText::TextVisitor
  # ... your overridden methods here
end

# initializer somewhere
Rails.configuration.to_prepare do
  RicherText.default_renderer = HtmlVisitor.new  # if you had a HtmlVisitor also defined.
  RicherText.default_text_renderer = TextVisitor.new
end
```